### PR TITLE
Set GH_TOKEN for usage of gh in github actions

### DIFF
--- a/.github/workflows/depandabot-auto-merge.yaml
+++ b/.github/workflows/depandabot-auto-merge.yaml
@@ -16,10 +16,10 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
+          GH_TOKEN: ${{secrets.BOT_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
+          GH_TOKEN: ${{secrets.BOT_TOKEN}}
       


### PR DESCRIPTION
Previous CI runs complained:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```